### PR TITLE
Ensure achievements/friends ids are str

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -141,7 +141,7 @@ class FinalFantasyXIVPlugin(Plugin):
         account_friends = self._ffxiv_api.get_account_friends()
 
         for friend in account_friends:
-            friends.append(FriendInfo(friend['ID'], friend['Name']))
+            friends.append(FriendInfo(str(friend['ID']), friend['Name']))
 
         return friends
 
@@ -170,7 +170,7 @@ class FinalFantasyXIVPlugin(Plugin):
         achievements = list()
 
         for achievement in self._ffxiv_api.get_account_achievements():
-            achievements.append(Achievement(int(achievement['Date']), achievement['ID']))
+            achievements.append(Achievement(int(achievement['Date']), str(achievement['ID'])))
 
         return achievements
 


### PR DESCRIPTION
I'm not sure what is returned from API, but based on sample from https://xivapi.com/Achievement?page=1 looks like it may be integer (json number), but API requires string. @RZetko please reject if I'm wrong.