### PR TITLE
Add local play time tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,25 +13,21 @@ down to community integrations and click connect on Final Fantasy XIV integratio
 # Features
 
 ## Supported
-
 * Launching and uninstalling game
-
 * Detecting if game is running
-
 * Syncing friends
 
 ## Unsupported
-
 * Achievements syncing - unsupported by platform (already implemented in code, if platform receives support for it, it should automatically work)
-
 * Installing game - unsupported by platform (already implemented in code, if platform receives support for it, it should automatically work)
-
 * Playtime tracking - unsupported by XIVAPI; local play time tracking is limited to one galaxy instance (if you try to play on multiple PCs, only local play time from the last PC will be used)
 
 # Working with code
 
 ## Before starting
-Install Python extensions (shuold not be needed) `pip install -r requirements.txt -t ./modules --implementation cp --python-version 37 --only-binary=:all:`
+Install Python extensions (should not be needed) `pip install -r requirements.txt -t ./modules --implementation cp --python-version 37 --only-binary=:all: --upgrade`
+
+If you have 64-bit version of Python set as default, you'll need to have 32-bit version installed as well sid-by-side and use `py -3.7-32 -m pip install -r requirements.txt -t ./modules --implementation cp --python-version 37 --only-binary=:all: --upgrade`
 
 ## Files and folders
 * ./html/ - folder with html files that will popup when first connecting integration

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ down to community integrations and click connect on Final Fantasy XIV integratio
 
 * Installing game - unsupported by platform (already implemented in code, if platform receives support for it, it should automatically work)
 
-* Playtime tracking - unsupported by XIVAPI
+* Playtime tracking - unsupported by XIVAPI; local play time tracking is limited to one galaxy instance (if you try to play on multiple PCs, only local play time from the last PC will be used)
 
 # Working with code
 

--- a/ffxiv_api.py
+++ b/ffxiv_api.py
@@ -7,7 +7,6 @@ import sys
 import pprint
 import threading
 import tempfile
-import modules.urllib3 as urllib3
 
 from urllib.parse import parse_qs
 from typing import Dict, List
@@ -15,10 +14,10 @@ from http.server import HTTPServer, BaseHTTPRequestHandler
 from enum import Enum
 
 modules =  os.path.join(os.path.dirname(os.path.realpath(__file__)),'modules\\')
-
 if modules not in sys.path:
     sys.path.insert(0, modules)
 
+import modules.urllib3 as urllib3
 import modules.requests as requests
 
 class FFXIVAuthorizationResult(Enum):
@@ -105,7 +104,7 @@ class FFXIVAPI(object):
     API_URL_CHARACTER = 'character/'
     LOCALSERVER_HOST = '127.0.0.1'
     LOCALSERVER_PORT = 13338
-    INSTALL_URL = "http://gdl.square-enix.com/ffxiv/inst/ffxivsetup.exe"
+    INSTALL_URL = "https://gdl.square-enix.com/ffxiv/inst/ffxivsetup.exe"
 
     def __init__(self):
         self._server_thread = None

--- a/plugin.py
+++ b/plugin.py
@@ -267,7 +267,6 @@ class FinalFantasyXIVPlugin(Plugin):
 
     async def _is_running_internal(self, target_exes):
         running = False
-
         for process in psutil.process_iter():
             try:
                 if process.name().lower() in target_exes:
@@ -275,24 +274,26 @@ class FinalFantasyXIVPlugin(Plugin):
                     break
             except (psutil.AccessDenied, psutil.NoSuchProcess):
                 continue
-
             await asyncio.sleep(self.SLEEP_CHECK_RUNNING_ITER)
-
         return LocalGameState.Installed | LocalGameState.Running if running else LocalGameState.Installed
 
     async def _is_running(self):
         target_exes = [
-            "ffxivlauncher64.exe",
-            "ffxiv.exe",
             "ffxiv_dx11.exe",
-            "ffxivlauncher.exe"
+            "ffxivlauncher.exe",
+            "ffxiv.exe",
+            "ffxivupdater.exe",
+            "ffxivlauncher64.exe",
+            "ffxivupdater64.exe",
+            "ffxivboot.exe",
+            "ffxivboot64.exe"
         ]
         return await self._is_running_internal(target_exes)
 
     async def _is_running_no_launcher(self):
         target_exes = [
-            "ffxiv.exe",
-            "ffxiv_dx11.exe"
+            "ffxiv_dx11.exe",
+            "ffxiv.exe"
         ]
         return await self._is_running_internal(target_exes)
 

--- a/plugin.py
+++ b/plugin.py
@@ -3,17 +3,22 @@ import sys
 import asyncio
 import logging
 import subprocess
+import datetime
+import time
 import modules.psutil as psutil
 import ffxiv_localgame
 import ffxiv_tools
 
-from typing import List
+from typing import List, Optional
 from version import __version__
+from datetime import datetime, timezone, timedelta
 from ffxiv_api import FFXIVAPI
 from modules.galaxy.api.errors import BackendError, InvalidCredentials
 from modules.galaxy.api.consts import Platform, LicenseType, LocalGameState
 from modules.galaxy.api.plugin import Plugin, create_and_run_plugin
 from modules.galaxy.api.types import Achievement, Authentication, NextStep, Dlc, LicenseInfo, Game, GameTime, LocalGame, FriendInfo
+
+logger = logging.getLogger(__name__)
 
 class FinalFantasyXIVPlugin(Plugin):
     SLEEP_CHECK_STATUS = 5
@@ -26,6 +31,8 @@ class FinalFantasyXIVPlugin(Plugin):
         self._task_check_for_running  = None
         self._check_statuses_task = None
         self._cached_game_statuses = {}
+        self._cached_game_statuses_no_launcher = {}
+        self._process_check_time = None
 
     def tick(self):
         if self._check_statuses_task is None or self._check_statuses_task.done():
@@ -36,11 +43,41 @@ class FinalFantasyXIVPlugin(Plugin):
 
         if local_games:
             for game in local_games:
+                main_process_state = await self._is_running_no_launcher()
+                cached_state_no_launcher = self._cached_game_statuses_no_launcher.get(game.game_id) or LocalGameState.None_
+                if bool(main_process_state & LocalGameState.Running):
+                    #logger.debug("Game client is running")
+                    # we were running before, so we need to update play time
+                    if bool(cached_state_no_launcher & LocalGameState.Running):
+                        current_time = datetime.now(timezone.utc)
+                        delta = current_time - self._process_check_time
+                        self._add_time_played(game.game_id, delta)
+                        self._process_check_time = current_time
+                        #logger.debug(f'Added {str(delta)} of play time')
+                    # we started to play somewhere between, some time might've been lost, but that's ok
+                    else:
+                        logger.debug("Started play time tracking")
+                        self._cached_game_statuses_no_launcher[game.game_id] = main_process_state
+                        self._process_check_time = datetime.now(timezone.utc)
+                else:
+                    # we stopped playing since last check, so we need to push update play time stats to galaxy
+                    if bool(cached_state_no_launcher & LocalGameState.Running):
+                        time_played = int(self._get_time_played(game.game_id) / timedelta(minutes=1))
+                        time_stamp = self._get_last_played_time(game.game_id)
+                        self.update_game_time(GameTime(game.game_id, time_played, time_stamp))
+                        self.push_cache()
+                        logger.debug(f'Updated galaxy stats with {time_played} minutes of play time')
+                    self._cached_game_statuses_no_launcher[game.game_id] = main_process_state
+
                 game.local_game_state = await self._is_running()
                 if game.local_game_state == self._cached_game_statuses.get(game.game_id):
                     continue
+
+                #logger.debug(f'Game or launcher status changed to {game.local_game_state}')
                 self.update_local_game_status(LocalGame(game.game_id, game.local_game_state))
                 self._cached_game_statuses[game.game_id] = game.local_game_state
+                self.push_cache()
+
         else:
             self.update_local_game_status(LocalGame("final_fantasy_xiv_shadowbringers", LocalGameState.None_))
             self._cached_game_statuses["final_fantasy_xiv_shadowbringers"] = LocalGameState.None_
@@ -49,7 +86,7 @@ class FinalFantasyXIVPlugin(Plugin):
 
     async def authenticate(self, stored_credentials=None):
         if not stored_credentials:
-            logging.info("No stored credentials")
+            logger.info("No stored credentials")
 
             AUTH_PARAMS = {
                 "window_title": "Login to Final Fantasy XIV Lodestone",
@@ -68,7 +105,7 @@ class FinalFantasyXIVPlugin(Plugin):
             auth_passed = self._ffxiv_api.do_auth_character(stored_credentials['character_id'])
 
             if not auth_passed:
-                logging.warning("plugin/authenticate: stored credentials are invalid")
+                logger.warning("plugin/authenticate: stored credentials are invalid")
 
                 raise InvalidCredentials()
             
@@ -80,7 +117,7 @@ class FinalFantasyXIVPlugin(Plugin):
         character_id = self._ffxiv_api.get_character_id()
 
         if not character_id:
-            logging.error("plugin/pass_login_credentials: character_id is None!")
+            logger.error("plugin/pass_login_credentials: character_id is None!")
 
             raise InvalidCredentials()
 
@@ -125,6 +162,10 @@ class FinalFantasyXIVPlugin(Plugin):
             if dlc == "ex3":
                 dlc_id = "Shadowbringers"
                 dlc_name = "Final Fantasy XIV: Shadowbringers"
+
+            if dlc == "ex4":
+                dlc_id = "Endwalker"
+                dlc_name = "Final Fantasy XIV: Endwalker"
 
             dlcs.append(Dlc(dlc_id = dlc_id, dlc_title = dlc_name, license_info = LicenseInfo(license_type = LicenseType.SinglePurchase)))
 
@@ -178,14 +219,53 @@ class FinalFantasyXIVPlugin(Plugin):
         # self.requires_authentication()
         await super()._start_achievements_import(game_ids)
 
-    async def _is_running(self):
-        target_exes = [
-            "ffxivlauncher64.exe",
-            "ffxiv.exe",
-            "ffxiv_dx11.exe",
-            "ffxivlauncher.exe"
-        ]
+    async def get_game_time(self, game_id: str, context: None) -> GameTime:
+        time_played = int(self._get_time_played(game_id) / timedelta(minutes=1))
+        time_stamp = self._get_last_played_time(game_id)
+        #logger.debug(f'Got game time: {time_played} minutes')
+        return GameTime(
+            game_id=game_id,
+            time_played=time_played,
+            last_played_time=time_stamp,
+        )
 
+    def _get_time_played(self, game_id: str) -> timedelta:
+        key = self._time_played_key(game_id)
+        days_key = f'{key}_d'
+        if not days_key in self.persistent_cache:
+            #logger.debug(f'Got no play time in persistent cache, returning default value')
+            return timedelta()
+
+        days = int(self.persistent_cache[days_key])
+        seconds = int(self.persistent_cache[f'{key}_s'])
+        microseconds = int(self.persistent_cache[f'{key}_t'])
+        result = timedelta(days=days, seconds=seconds, microseconds=microseconds)
+        #logger.debug(f'Got play time {str(result)} from persistent cache (d={days}, s={seconds}, t={microseconds})')
+        return result
+
+    def _set_time_played(self, game_id: str, delta: timedelta):
+        key = self._time_played_key(game_id)
+        days = int(delta / timedelta(days=1))
+        seconds = int((delta - timedelta(days=days)) / timedelta(seconds=1))
+        microseconds = int((delta - timedelta(days=days, seconds=seconds)) / timedelta(microseconds=1))
+        self.persistent_cache[f'{key}_d'] = str(days)
+        self.persistent_cache[f'{key}_s'] = str(seconds)
+        self.persistent_cache[f'{key}_t'] = str(microseconds)
+        #logger.debug(f'Set play time {str(delta)} to persistent cache (d={days}, s={seconds}, t={microseconds})')
+
+    def _get_last_played_time(self, game_id: str) -> Optional[timedelta]:
+        key = self._last_played_time_key(game_id)
+        return int(self.persistent_cache[key]) if key in self.persistent_cache else None
+    
+    def _add_time_played(self, game_id: str, delta: timedelta):
+        tracked_time = self._get_time_played(game_id)
+        #logger.debug(f'Tracked time before: {str(tracked_time)} (+{str(delta)})')
+        tracked_time += delta
+        #logger.debug(f'Tracked time after: {str(tracked_time)}')
+        self._set_time_played(game_id, tracked_time)
+        self.persistent_cache[self._last_played_time_key(game_id)] = str(int(time.time()))
+
+    async def _is_running_internal(self, target_exes):
         running = False
 
         for process in psutil.process_iter():
@@ -199,6 +279,30 @@ class FinalFantasyXIVPlugin(Plugin):
             await asyncio.sleep(self.SLEEP_CHECK_RUNNING_ITER)
 
         return LocalGameState.Installed | LocalGameState.Running if running else LocalGameState.Installed
+
+    async def _is_running(self):
+        target_exes = [
+            "ffxivlauncher64.exe",
+            "ffxiv.exe",
+            "ffxiv_dx11.exe",
+            "ffxivlauncher.exe"
+        ]
+        return await self._is_running_internal(target_exes)
+
+    async def _is_running_no_launcher(self):
+        target_exes = [
+            "ffxiv.exe",
+            "ffxiv_dx11.exe"
+        ]
+        return await self._is_running_internal(target_exes)
+
+    @staticmethod
+    def _time_played_key(game_id: str) -> str:
+        return f'time{game_id}'
+
+    @staticmethod
+    def _last_played_time_key(game_id: str) -> str:
+        return f'last{game_id}'
 
 def main():
     create_and_run_plugin(FinalFantasyXIVPlugin, sys.argv)


### PR DESCRIPTION
This is not ideal, but I think it's better than nothing.
Local play time tracking means that if you have multiple Galaxy instances, it will sync the play time from that instance instead of adding them all together.
Afaik, galaxy does not sync plugin settings, and proposal to handle local play time automatically is still open and not implemented.
Still, for many people this will be helpful, I think.

Also fixed plugin logging.